### PR TITLE
Remove deprecated ansible features

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,7 +12,7 @@
 - name: Run pre hooks
   command: "{{ item }} chdir={{ app_directory }}"
   with_items: "{{ app_pre_hooks }}"
-  environment: app_environment
+  environment: "{{ app_environment }}"
   tags:
     - app
     - hook
@@ -66,7 +66,7 @@
 - name: Run post hooks
   command: "{{ item }} chdir={{ app_directory }}"
   with_items: "{{ app_post_hooks }}"
-  environment: app_environment
+  environment: "{{ app_environment }}"
   tags:
     - app
     - hook

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,8 +1,8 @@
 ---
 - name: Install packages required for python development
   apt: pkg={{ item }} state=present
-  sudo: true
-  with_items: app_packages
+  become: true
+  with_items: "{{ app_packages }}"
   tags:
     - apt
     - setup
@@ -11,7 +11,7 @@
 
 - name: Run pre hooks
   command: "{{ item }} chdir={{ app_directory }}"
-  with_items: app_pre_hooks
+  with_items: "{{ app_pre_hooks }}"
   environment: app_environment
   tags:
     - app
@@ -26,7 +26,7 @@
 
 - stat: path={{ app_config }}
   delegate_to: localhost
-  sudo: false
+  become: false
   register: app_config_file
   when: app_config is defined and app_config
   tags:
@@ -65,7 +65,7 @@
 
 - name: Run post hooks
   command: "{{ item }} chdir={{ app_directory }}"
-  with_items: app_post_hooks
+  with_items: "{{ app_post_hooks }}"
   environment: app_environment
   tags:
     - app

--- a/tasks/npm.yml
+++ b/tasks/npm.yml
@@ -1,7 +1,7 @@
 ---
 - name: Add the nodejs repository
   apt_repository: repo=ppa:chris-lea/node.js state=present
-  sudo: true
+  become: true
   tags:
     - apt
     - npm
@@ -9,7 +9,7 @@
 
 - name: Install the nodejs package
   apt: pkg=nodejs state=present
-  sudo: true
+  become: true
   tags:
     - apt
     - npm

--- a/tasks/pip.yml
+++ b/tasks/pip.yml
@@ -1,7 +1,7 @@
 ---
 - name: Install the latest pip version
   pip: name=pip extra_args='-U'
-  sudo: true
+  become: true
   tags:
     - pip
     - setup


### PR DESCRIPTION
As per https://docs.ansible.com/ansible/porting_guide_2.0.html

- `s/sudo/become/g`

- Use the full jinja2 variable syntax when specifying complex args
  as a variable, e.g. `{{ app_packages }}` instead of `app_packages`.