### PR TITLE
Fix to issue's URL typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,5 +41,5 @@ Licensed under the [MIT license](http://mit-license.org/vitalk).
 
 Created by Vital Kudzelka.
 
-Open [a GitHub issue](https://github.com/vitalk/ansible-flask-app/issues) if
+Open [a GitHub issue](https://github.com/vitalk/ansible-flaskapp/issues) if
 you have any suggestion or found a bug.


### PR DESCRIPTION
Due to rename of your repo (In my guess), Your readme issue's URL might be broken.

So I updated issue's URL in README.